### PR TITLE
Get editor from config instead of environment variable

### DIFF
--- a/config.template.toml
+++ b/config.template.toml
@@ -10,3 +10,6 @@ temperature = 1.0
 top_p = 1.0
 frequency_penalty = 0
 presence_penalty = 0
+
+[ui]
+editor_command = ["gedit", "--standalone"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,7 @@ use serde::Deserialize;
 pub struct Config {
     pub api: Api,
     pub chat: ChatConfig,
+    pub ui: Ui,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -35,4 +36,9 @@ pub struct ChatConfig {
     pub top_p: f32,
     pub frequency_penalty: f32,
     pub presence_penalty: f32,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct Ui {
+    pub editor_command: Vec<String>,
 }

--- a/src/events.rs
+++ b/src/events.rs
@@ -3,6 +3,7 @@ use crate::state::State;
 use crate::ui::{UiState, ViewTab};
 use anyhow::{Context, Result};
 use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use std::process::Command;
 
 const API_ERROR_FEEDBACK: &str = "An error occured, see debug logs.";
 const API_ERROR_SYSTEM_MESSAGE: &str = "Failed to get a response from the assistant.";
@@ -94,7 +95,8 @@ async fn handle_conversation_keys(
             do_prompt(state, ui_state).await?;
         }
         (KeyCode::Char('e'), KeyModifiers::ALT) => {
-            let message_text = get_message_text_from_editor().context("get message text from editor")?;
+            let message_text = get_message_text_from_editor(&state.config)
+                .context("get message text from editor")?;
             ui_state.textarea.select_all();
             ui_state.textarea.cut();
             ui_state.textarea.insert_str(&message_text);
@@ -107,17 +109,30 @@ async fn handle_conversation_keys(
     Ok(HandleEventResult::None)
 }
 
-fn get_message_text_from_editor() -> Result<String> {
-    let editor = std::env::var("EDITOR").context("get EDITOR environment variable")?;
+fn get_message_text_from_editor(config: &crate::Config) -> Result<String> {
     let user_home_dir = std::env::var("HOME").context("get HOME environment variable")?;
     let message_file = std::path::Path::new(&user_home_dir).join(MESSAGE_FILE);
-    let message_dir = message_file.parent().expect("get message file parent directory");
+    let message_dir = message_file
+        .parent()
+        .expect("get message file parent directory");
     std::fs::create_dir_all(message_dir).context("create directory for message file")?;
-    let editor_process_output = std::process::Command::new(editor).arg(&message_file).output().context("run editor")?;
+    let mut editor_command_iter = config.ui.editor_command.iter();
+    let editor_process_output =
+        Command::new(editor_command_iter.next().context("editor command empty")?)
+            .args(editor_command_iter.collect::<Vec<&String>>())
+            .arg(&message_file)
+            .output()
+            .context("run editor")?;
     if !editor_process_output.status.success() {
-        anyhow::bail!(format!("editor process failed: {}", editor_process_output.status));
+        anyhow::bail!(format!(
+            "editor process failed: {}",
+            editor_process_output.status
+        ));
     }
-    let message_text = std::fs::read_to_string(message_file).context("read message text from file")?.trim().to_owned();
+    let message_text = std::fs::read_to_string(message_file)
+        .context("read message text from file")?
+        .trim()
+        .to_owned();
     Ok(message_text)
 }
 


### PR DESCRIPTION
In the template config, `gedit` was chosen since it is very likely to be included in most Linux distributions.