### PR TITLE
Test template configuration file

### DIFF
--- a/src/events.rs
+++ b/src/events.rs
@@ -109,7 +109,7 @@ async fn handle_conversation_keys(
     Ok(HandleEventResult::None)
 }
 
-fn get_message_text_from_editor(config: &crate::Config) -> Result<String> {
+fn get_message_text_from_editor(config: &crate::config::Config) -> Result<String> {
     let user_home_dir = std::env::var("HOME").context("get HOME environment variable")?;
     let message_file = std::path::Path::new(&user_home_dir).join(MESSAGE_FILE);
     let message_dir = message_file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,8 @@
+pub mod api;
+pub mod config;
+pub mod events;
+pub mod state;
+pub mod ui;
+
+const APP_TITLE: &str = "HummingParrot";
+const APP_TITLE_FULL: &str = "HummingParrot AI Chat Client";

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,18 +3,12 @@ use crossterm::ExecutableCommand;
 use ratatui::prelude::{Backend, CrosstermBackend, Terminal};
 use std::{io::stdout, path::Path};
 
-mod api;
-mod config;
-mod events;
-mod state;
-mod ui;
-
-use config::Config;
-use state::State;
+use hummingparrot::config::Config;
+use hummingparrot::events;
+use hummingparrot::state::State;
+use hummingparrot::ui;
 
 const FRAME_DURATION_MS: u64 = 50;
-const APP_TITLE: &str = "HummingParrot";
-const APP_TITLE_FULL: &str = "HummingParrot AI Chat Client";
 
 #[tokio::main]
 async fn main() {

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -1,0 +1,12 @@
+#[cfg(test)]
+mod config_tests {
+    use hummingparrot::config::Config;
+    use std::path::Path;
+
+    #[test]
+    fn template() {
+        let config_toml = std::fs::read_to_string(Path::new("config.template.toml"))
+            .expect("read config template file");
+        toml::from_str::<Config>(&config_toml).expect("parse config template file toml");
+    }
+}


### PR DESCRIPTION
This also moves the module definitions to `lib.rs` instead of `main.rs` in order to allow the tests to use the modules.